### PR TITLE
Complete WebRTC direct groundwork

### DIFF
--- a/src/libp2p/Directory.Packages.props
+++ b/src/libp2p/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Native.Quic.MsQuic.OpenSSL" Version="2.5.5" />
+    <PackageVersion Include="Microsoft.Native.Quic.MsQuic.OpenSSL" Version="2.5.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Testing.Platform" Version="1.9.1" />
@@ -35,8 +35,8 @@
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="SimpleBase" Version="4.0.2" />
     <PackageVersion Include="SIPSorcery" Version="10.0.3" />
     <PackageVersion Include="System.Formats.Cbor" Version="10.0.0" />

--- a/src/libp2p/Libp2p.Core.Benchmarks/Benchmarks.cs
+++ b/src/libp2p/Libp2p.Core.Benchmarks/Benchmarks.cs
@@ -23,8 +23,8 @@ public class ChannelsBenchmark
     //    }
     //}
 
-    IChannel chan;
-    IChannel revChan;
+    private IChannel chan = null!;
+    private IChannel revChan = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/src/libp2p/Libp2p.Core.TestsBase/E2e/TestBuilder.cs
+++ b/src/libp2p/Libp2p.Core.TestsBase/E2e/TestBuilder.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 using Microsoft.Extensions.Logging;
@@ -26,19 +26,37 @@ public class TestBuilder(IServiceProvider? serviceProvider = null) : PeerFactory
     }
 }
 
-public class TestPeerFactory(IProtocolStackSettings protocolStackSettings, PeerStore peerStore, ActivitySource? activitySource = null, ILoggerFactory? loggerFactory = null) : PeerFactory(protocolStackSettings, peerStore, activitySource)
+public class TestPeerFactory : PeerFactory
 {
-    ConcurrentDictionary<PeerId, ILocalPeer> peers = new();
+    private readonly IProtocolStackSettings _protocolStackSettings;
+    private readonly PeerStore _peerStore;
+    private readonly ActivitySource? _activitySource;
+    private readonly ILoggerFactory? _loggerFactory;
+    private readonly ConcurrentDictionary<PeerId, ILocalPeer> _peers = new();
+
+    public TestPeerFactory(IProtocolStackSettings protocolStackSettings, PeerStore peerStore, ActivitySource? activitySource = null, ILoggerFactory? loggerFactory = null)
+        : base(protocolStackSettings, peerStore, activitySource)
+    {
+        _protocolStackSettings = protocolStackSettings;
+        _peerStore = peerStore;
+        _activitySource = activitySource;
+        _loggerFactory = loggerFactory;
+    }
 
     public override ILocalPeer Create(Identity? identity = default)
     {
         ArgumentNullException.ThrowIfNull(identity);
-        return peers.GetOrAdd(identity.PeerId, (p) => new TestLocalPeer(identity, protocolStackSettings, peerStore, activitySource, loggerFactory));
+        return _peers.GetOrAdd(identity.PeerId, _ => new TestLocalPeer(identity, _protocolStackSettings, _peerStore, _activitySource, _loggerFactory));
     }
 }
 
-internal class TestLocalPeer(Identity id, IProtocolStackSettings protocolStackSettings, PeerStore peerStore, ActivitySource? activitySource = null, ILoggerFactory? loggerFactory = null) : LocalPeer(id, peerStore, protocolStackSettings, activitySource, null, loggerFactory)
+internal class TestLocalPeer : LocalPeer
 {
+    public TestLocalPeer(Identity id, IProtocolStackSettings protocolStackSettings, PeerStore peerStore, ActivitySource? activitySource = null, ILoggerFactory? loggerFactory = null)
+        : base(id, peerStore, protocolStackSettings, activitySource, null, loggerFactory)
+    {
+    }
+
     protected override async Task ConnectedTo(ISession session, bool isDialer)
     {
         await session.DialAsync<IdentifyProtocol>();

--- a/src/libp2p/Libp2p.Core.TestsBase/LocalPeerStub.cs
+++ b/src/libp2p/Libp2p.Core.TestsBase/LocalPeerStub.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 using Multiformats.Address;
@@ -47,7 +47,7 @@ public class LocalPeerStub : ILocalPeer
         return ValueTask.CompletedTask;
     }
 
-    public Task StartListenAsync(Multiaddress[] addrs, CancellationToken token = default)
+    public Task StartListenAsync(Multiaddress[]? addrs = default, CancellationToken token = default)
     {
         return Task.CompletedTask;
     }

--- a/src/libp2p/Libp2p.Core/MultiaddressProtocolRegistration.cs
+++ b/src/libp2p/Libp2p.Core/MultiaddressProtocolRegistration.cs
@@ -12,7 +12,9 @@ internal static class MultiaddressProtocolRegistration
 {
     private static int _initialized;
 
+#pragma warning disable CA2255 // Multiaddr protocol setup must happen before callers decode /webrtc-direct addresses.
     [ModuleInitializer]
+#pragma warning restore CA2255
     internal static void Register()
     {
         EnsureRegistered();

--- a/src/libp2p/Libp2p.Core/Stream.cs
+++ b/src/libp2p/Libp2p.Core/Stream.cs
@@ -1,14 +1,12 @@
-// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
-using Microsoft.Extensions.Logging;
 using Nethermind.Libp2p.Core;
 using System.Buffers;
 
 public class ChannelStream : Stream
 {
     private readonly IChannel _chan;
-    private readonly ILogger<ChannelStream> logger;
     private bool _disposed = false;
     private bool _canRead = true;
     private bool _canWrite = true;

--- a/src/libp2p/Libp2p.Core/TransportContext.cs
+++ b/src/libp2p/Libp2p.Core/TransportContext.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 using Multiformats.Address;
@@ -6,29 +6,53 @@ using System.Diagnostics;
 
 namespace Nethermind.Libp2p.Core;
 
-public class TransportContext(LocalPeer peer, ProtocolRef proto, bool isListener, Activity? activity) : ITransportContext
+public class TransportContext : ITransportContext
 {
-    public Identity Identity => peer.Identity;
-    public ILocalPeer Peer => peer;
-    public bool IsListener => isListener;
-    public Activity? Activity { get; } = activity;
+    private readonly LocalPeer _peer;
+    private readonly ProtocolRef _proto;
+
+    public TransportContext(LocalPeer peer, ProtocolRef proto, bool isListener, Activity? activity)
+    {
+        _peer = peer;
+        _proto = proto;
+        IsListener = isListener;
+        Activity = activity;
+    }
+
+    public Identity Identity => _peer.Identity;
+    public ILocalPeer Peer => _peer;
+    public bool IsListener { get; }
+    public Activity? Activity { get; }
 
     public void ListenerReady(Multiaddress addr)
     {
-        peer.ListenerReady(this, addr);
+        _peer.ListenerReady(this, addr);
     }
 
     public virtual INewConnectionContext CreateConnection()
     {
-        return peer.CreateConnection(proto, null, isListener, Activity);
+        return _peer.CreateConnection(_proto, null, IsListener, Activity);
     }
 }
 
-public class DialerTransportContext(LocalPeer peer, LocalPeer.Session session, ProtocolRef proto, Activity? context)
-    : TransportContext(peer, proto, false, context)
+public class DialerTransportContext : TransportContext
 {
+    private readonly LocalPeer _peer;
+    private readonly LocalPeer.Session _session;
+    private readonly ProtocolRef _proto;
+    private readonly Activity? _activity;
+
+    public DialerTransportContext(LocalPeer peer, LocalPeer.Session session, ProtocolRef proto, Activity? activity)
+        : base(peer, proto, false, activity)
+    {
+        _peer = peer;
+        _session = session;
+        _proto = proto;
+        _activity = activity;
+    }
+
     public override INewConnectionContext CreateConnection()
     {
-        return peer.CreateConnection(proto, session, false, context);
+        return _peer.CreateConnection(_proto, _session, false, _activity);
     }
 }

--- a/src/libp2p/Libp2p.Protocols.KadDht.Tests/Integration/DhtNodeTests.cs
+++ b/src/libp2p/Libp2p.Protocols.KadDht.Tests/Integration/DhtNodeTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -129,7 +129,7 @@ public class DhtNodeTests
 
         // Act & Assert
         Assert.That(node.Equals(null), Is.False);
-        Assert.That(node.Equals((object?)null), Is.False);
+        Assert.That(object.Equals(node, null), Is.False);
     }
 
     [Test]

--- a/src/libp2p/Libp2p.Protocols.Noise/NoiseProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.Noise/NoiseProtocol.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 using System.Buffers;
@@ -17,7 +17,7 @@ namespace Nethermind.Libp2p.Protocols;
 
 /// <summary>
 /// </summary>
-public class NoiseProtocol(MultiplexerSettings? multiplexerSettings = null, ILoggerFactory? loggerFactory = null) : IConnectionProtocol
+public class NoiseProtocol : IConnectionProtocol
 {
     private readonly Protocol _protocol = new(
             HandshakePattern.XX,
@@ -25,7 +25,13 @@ public class NoiseProtocol(MultiplexerSettings? multiplexerSettings = null, ILog
             HashFunction.Sha256
         );
 
-    private readonly ILogger? _logger = loggerFactory?.CreateLogger<NoiseProtocol>();
+    private readonly ILogger? _logger;
+
+    public NoiseProtocol(MultiplexerSettings? multiplexerSettings = null, ILoggerFactory? loggerFactory = null)
+    {
+        _logger = loggerFactory?.CreateLogger<NoiseProtocol>();
+    }
+
     private NoiseExtensions _extensions => new()
     {
         StreamMuxers = { } // TODO: return the following after go question resolution:

--- a/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
+++ b/src/libp2p/Libp2p.Protocols.Pubsub/PubsubRouter.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 using Google.Protobuf;
@@ -104,7 +104,7 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
         public bool IsFloodSub => Protocol == PubsubProtocol.Floodsub;
 
         public ConnectionInitiation InitiatedBy { get; internal set; }
-        public Multiaddress Address { get; internal set; }
+        public Multiaddress Address { get; internal set; } = null!;
 
         // Peer scoring (Gossipsub v1.1)
         public PeerScore Score { get; internal set; }
@@ -224,7 +224,8 @@ public partial class PubsubRouter : IRoutingStateContainer, IDisposable
     {
         try
         {
-            ISession session = await localPeer.DialAsync(addrs, token);
+            ILocalPeer peer = localPeer ?? throw new InvalidOperationException("Router has not been started.");
+            ISession session = await peer.DialAsync(addrs, token);
 
             if (!peerState.ContainsKey(session.RemoteAddress.Get<P2P>().ToString()))
             {

--- a/src/libp2p/Libp2p.Protocols.Quic.Tests/CertificateTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Quic.Tests/CertificateTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 using Nethermind.Libp2p.Core;
@@ -12,7 +12,7 @@ public class CertificateTests
 {
     [TestCaseSource(nameof(CertificatesSerialized))]
     public bool Test_CertificateDeserialization(byte[] certificateBytes, string peerId) =>
-        CertificateHelper.ValidateCertificate(new X509Certificate2(certificateBytes), peerId);
+        CertificateHelper.ValidateCertificate(X509CertificateLoader.LoadCertificate(certificateBytes), peerId);
 
     public static IEnumerable<TestCaseData> CertificatesSerialized()
     {

--- a/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/RequestResponseProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.RequestResponse.Tests/RequestResponseProtocolTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 using NUnit.Framework;
@@ -11,16 +11,16 @@ namespace Nethermind.Libp2p.Protocols.Tests;
 
 public class TestRequest : IMessage<TestRequest>
 {
-    public string Message { get; set; }
+    public string Message { get; set; } = string.Empty;
     public int Value { get; set; }
 
     public static MessageParser<TestRequest> Parser { get; } =
         new MessageParser<TestRequest>(() => new TestRequest());
-    public static MessageDescriptor StaticDescriptor { get; } = null;
+    public static MessageDescriptor StaticDescriptor { get; } = null!;
     MessageDescriptor IMessage.Descriptor => StaticDescriptor;
 
     public TestRequest Clone() => new TestRequest { Message = Message, Value = Value };
-    public bool Equals(TestRequest other) => other != null && Message == other.Message && Value == other.Value;
+    public bool Equals(TestRequest? other) => other != null && Message == other.Message && Value == other.Value;
     public void MergeFrom(TestRequest message) { Message = message.Message; Value = message.Value; }
     public void MergeFrom(CodedInputStream input) { Message = input.ReadString(); Value = input.ReadInt32(); }
     public void WriteTo(CodedOutputStream output) { output.WriteString(Message); output.WriteInt32(Value); }
@@ -30,16 +30,16 @@ public class TestRequest : IMessage<TestRequest>
 // Mock interface initialization for IMessage->TestResponse
 public class TestResponse : IMessage<TestResponse>
 {
-    public string Echo { get; set; }
+    public string Echo { get; set; } = string.Empty;
     public int ProcessedValue { get; set; }
 
     public static MessageParser<TestResponse> Parser { get; } =
         new MessageParser<TestResponse>(() => new TestResponse());
-    public static MessageDescriptor StaticDescriptor { get; } = null;
+    public static MessageDescriptor StaticDescriptor { get; } = null!;
     MessageDescriptor IMessage.Descriptor => StaticDescriptor;
 
     public TestResponse Clone() => new TestResponse { Echo = Echo, ProcessedValue = ProcessedValue };
-    public bool Equals(TestResponse other) =>
+    public bool Equals(TestResponse? other) =>
         other != null && Echo == other.Echo && ProcessedValue == other.ProcessedValue;
     public void MergeFrom(TestResponse message)
     {
@@ -82,7 +82,7 @@ public class RequestResponseProtocolTests
 
         // Deserialization handler check
         var sampleRequest = new TestRequest { Message = "hi", Value = 5 };
-        var result = await handler(sampleRequest, null);
+        var result = await handler(sampleRequest, Substitute.For<ISessionContext>());
 
         Assert.That(result.Echo, Is.EqualTo("hi"));
         Assert.That(result.ProcessedValue, Is.EqualTo(10));
@@ -129,10 +129,11 @@ public class RequestResponseExtensionsTests
         var handler = new Func<TestRequest, ISessionContext, Task<TestResponse>>((req, ctx) =>
             Task.FromResult(new TestResponse()));
 
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.That(() =>
             mockBuilder.AddRequestResponseProtocol<TestRequest, TestResponse>(
                 null!,
-                handler));
+                handler),
+            Throws.TypeOf<ArgumentNullException>());
     }
 
     [Test]

--- a/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
+++ b/src/libp2p/Libp2p.Protocols.Tls.Tests/TlsProtocolTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 using Microsoft.Extensions.Logging;
@@ -163,7 +163,7 @@ public class TlsProtocolTests
                     ServerCertificate = serverCert,
                     ClientCertificateRequired = true,
                     RemoteCertificateValidationCallback = (_, cert, _, _) =>
-                        CertificateHelper.ValidateCertificate(cert as X509Certificate2, null),
+                        cert is X509Certificate2 x509 && CertificateHelper.ValidateCertificate(x509, null),
                 };
 
                 using SslStream sslStream = new(networkStream, false, serverOptions.RemoteCertificateValidationCallback);
@@ -198,7 +198,7 @@ public class TlsProtocolTests
                     ClientCertificates = [clientCert],
                     EnabledSslProtocols = SslProtocols.Tls13,
                     RemoteCertificateValidationCallback = (_, cert, _, _) =>
-                        CertificateHelper.ValidateCertificate(cert as X509Certificate2, null),
+                        cert is X509Certificate2 x509 && CertificateHelper.ValidateCertificate(x509, null),
                     CertificateChainPolicy = new X509ChainPolicy
                     {
                         RevocationMode = X509RevocationMode.NoCheck,
@@ -265,7 +265,7 @@ public class TlsProtocolTests
                 ServerCertificate = serverCert,
                 ClientCertificateRequired = true,
                 RemoteCertificateValidationCallback = (_, cert, _, _) =>
-                    CertificateHelper.ValidateCertificate(cert as X509Certificate2, null),
+                    cert is X509Certificate2 x509 && CertificateHelper.ValidateCertificate(x509, null),
             };
 
             using SslStream sslStream = new(networkStream, false, opts.RemoteCertificateValidationCallback);
@@ -293,7 +293,7 @@ public class TlsProtocolTests
                 ClientCertificates = [clientCert],
                 EnabledSslProtocols = SslProtocols.Tls13,
                 RemoteCertificateValidationCallback = (_, cert, _, _) =>
-                    CertificateHelper.ValidateCertificate(cert as X509Certificate2, null),
+                    cert is X509Certificate2 x509 && CertificateHelper.ValidateCertificate(x509, null),
                 CertificateChainPolicy = new X509ChainPolicy
                 {
                     RevocationMode = X509RevocationMode.NoCheck,

--- a/src/libp2p/Libp2p.Protocols.Tls/TlsProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.Tls/TlsProtocol.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 using System.Buffers;
@@ -14,16 +14,22 @@ using System.Text;
 
 namespace Nethermind.Libp2p.Protocols.Tls;
 
-public class TlsProtocol(MultiplexerSettings? multiplexerSettings = null, ILoggerFactory? loggerFactory = null) : IConnectionProtocol
+public class TlsProtocol : IConnectionProtocol
 {
     private readonly ECDsa _sessionKey = ECDsa.Create();
-    private readonly ILogger<TlsProtocol>? _logger = loggerFactory?.CreateLogger<TlsProtocol>();
+    private readonly ILogger<TlsProtocol>? _logger;
 
     // libp2p TLS spec requires "libp2p" as ALPN protocol
     private static readonly SslApplicationProtocol Libp2pProtocol = new("libp2p");
     public static List<SslApplicationProtocol> ApplicationProtocols => [Libp2pProtocol];
     public SslApplicationProtocol? LastNegotiatedApplicationProtocol { get; private set; }
     public string Id => "/tls/1.0.0";
+
+    public TlsProtocol(MultiplexerSettings? multiplexerSettings = null, ILoggerFactory? loggerFactory = null)
+    {
+        _ = multiplexerSettings;
+        _logger = loggerFactory?.CreateLogger<TlsProtocol>();
+    }
 
     public async Task ListenAsync(IChannel downChannel, IConnectionContext context)
     {
@@ -92,7 +98,7 @@ public class TlsProtocol(MultiplexerSettings? multiplexerSettings = null, ILogge
     // Use null-safe access; CertificateHelper.ValidateCertificate handles null peerId by
     // skipping peer-ID verification (still verifies the libp2p extension and signature).
     private static bool VerifyRemoteCertificate(Multiaddress? remotePeerAddress,
-        X509Certificate certificate)
+        X509Certificate? certificate)
     {
         // Per libp2p TLS spec: Must be single certificate, not a chain
         if (certificate is not X509Certificate2 x509Certificate2)

--- a/src/libp2p/Libp2p.Protocols.WebRtc.Tests/WebRtcDirectIntegrationTests.cs
+++ b/src/libp2p/Libp2p.Protocols.WebRtc.Tests/WebRtcDirectIntegrationTests.cs
@@ -16,8 +16,7 @@ public class WebRtcDirectIntegrationTests
     public async Task ListenAsync_AnnouncesWebRtcDirectAddressWithCerthash()
     {
         WebRtcDirectProtocol protocol = new();
-        ITransportContext context = Substitute.For<ITransportContext>();
-        context.Peer.Returns(Substitute.For<ILocalPeer>());
+        ITransportContext context = CreateContext(new Identity(), CreateCompletionSource(), out _);
 
         Multiaddress? announcedAddress = null;
         context
@@ -47,8 +46,7 @@ public class WebRtcDirectIntegrationTests
     public async Task ListenAsync_StopsOnCancellation()
     {
         WebRtcDirectProtocol protocol = new();
-        ITransportContext context = Substitute.For<ITransportContext>();
-        context.Peer.Returns(Substitute.For<ILocalPeer>());
+        ITransportContext context = CreateContext(new Identity(), CreateCompletionSource(), out _);
 
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(3));
         Task listenTask = protocol.ListenAsync(context, Multiaddress.Decode("/ip4/127.0.0.1/udp/0"), cts.Token);
@@ -75,16 +73,17 @@ public class WebRtcDirectIntegrationTests
     [Explicit("Manual end-to-end loopback for WebRTC-Direct handshake and upgrade.")]
     public async Task DialAndListen_UpgradesOnBothSides()
     {
-        WebRtcDirectProtocol protocol = new();
+        WebRtcDirectProtocol listenerProtocol = new();
+        WebRtcDirectProtocol dialerProtocol = new();
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(20));
 
         TaskCompletionSource listenerUpgrade = CreateCompletionSource();
         TaskCompletionSource dialerUpgrade = CreateCompletionSource();
 
-        ITransportContext listenerContext = CreateContext(listenerUpgrade, out Func<Multiaddress?> getListenerAddress);
-        ITransportContext dialerContext = CreateContext(dialerUpgrade, out _);
+        ITransportContext listenerContext = CreateContext(new Identity(), listenerUpgrade, out Func<Multiaddress?> getListenerAddress);
+        ITransportContext dialerContext = CreateContext(new Identity(), dialerUpgrade, out _);
 
-        Task listenerTask = protocol.ListenAsync(listenerContext, Multiaddress.Decode("/ip4/127.0.0.1/udp/0"), cts.Token);
+        Task listenerTask = listenerProtocol.ListenAsync(listenerContext, Multiaddress.Decode("/ip4/127.0.0.1/udp/0"), cts.Token);
         Multiaddress listenerAddress;
         try
         {
@@ -96,9 +95,9 @@ public class WebRtcDirectIntegrationTests
             return;
         }
 
-        Task dialTask = protocol.DialAsync(dialerContext, listenerAddress, cts.Token);
+        Task dialTask = dialerProtocol.DialAsync(dialerContext, listenerAddress, cts.Token);
 
-        await Task.WhenAll(listenerUpgrade.Task, dialerUpgrade.Task);
+        await Task.WhenAll(listenerUpgrade.Task, dialerUpgrade.Task, dialTask).WaitAsync(TimeSpan.FromSeconds(20));
 
         cts.Cancel();
         await Task.WhenAll(dialTask, listenerTask);
@@ -108,14 +107,15 @@ public class WebRtcDirectIntegrationTests
     [Explicit("Manual end-to-end loopback for fingerprint mismatch rejection.")]
     public async Task DialAndListen_RejectsWhenCerthashMismatches()
     {
-        WebRtcDirectProtocol protocol = new();
+        WebRtcDirectProtocol listenerProtocol = new();
+        WebRtcDirectProtocol dialerProtocol = new();
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(20));
 
         TaskCompletionSource listenerUpgrade = CreateCompletionSource();
-        ITransportContext listenerContext = CreateContext(listenerUpgrade, out Func<Multiaddress?> getListenerAddress);
-        ITransportContext dialerContext = CreateContext(CreateCompletionSource(), out _);
+        ITransportContext listenerContext = CreateContext(new Identity(), listenerUpgrade, out Func<Multiaddress?> getListenerAddress);
+        ITransportContext dialerContext = CreateContext(new Identity(), CreateCompletionSource(), out _);
 
-        Task listenerTask = protocol.ListenAsync(listenerContext, Multiaddress.Decode("/ip4/127.0.0.1/udp/0"), cts.Token);
+        Task listenerTask = listenerProtocol.ListenAsync(listenerContext, Multiaddress.Decode("/ip4/127.0.0.1/udp/0"), cts.Token);
         Multiaddress listenerAddress;
         try
         {
@@ -128,16 +128,20 @@ public class WebRtcDirectIntegrationTests
         }
         Multiaddress tamperedAddress = TamperCerthash(listenerAddress);
 
-        Assert.That(async () => await protocol.DialAsync(dialerContext, tamperedAddress, cts.Token), Throws.TypeOf<InvalidOperationException>());
+        Assert.That(
+            async () => await dialerProtocol.DialAsync(dialerContext, tamperedAddress, cts.Token).WaitAsync(TimeSpan.FromSeconds(10)),
+            Throws.TypeOf<InvalidOperationException>());
 
         cts.Cancel();
         await listenerTask;
     }
 
-    private static ITransportContext CreateContext(TaskCompletionSource upgradeSignal, out Func<Multiaddress?> getListenerAddress)
+    private static ITransportContext CreateContext(Identity identity, TaskCompletionSource upgradeSignal, out Func<Multiaddress?> getListenerAddress)
     {
         ITransportContext context = Substitute.For<ITransportContext>();
-        context.Peer.Returns(Substitute.For<ILocalPeer>());
+        ILocalPeer peer = Substitute.For<ILocalPeer>();
+        peer.Identity.Returns(identity);
+        context.Peer.Returns(peer);
 
         Multiaddress? listenerAddress = null;
         context.When(c => c.ListenerReady(Arg.Any<Multiaddress>())).Do(callInfo => listenerAddress = callInfo.Arg<Multiaddress>());
@@ -204,8 +208,10 @@ public class WebRtcDirectIntegrationTests
         }
 
         string value = parts[certhashIndex + 1];
-        char replacement = value[^1] == 'A' ? 'B' : 'A';
-        parts[certhashIndex + 1] = value[..^1] + replacement;
+        int indexToMutate = Math.Max(1, value.Length / 2);
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        char replacement = alphabet.First(c => c != value[indexToMutate]);
+        parts[certhashIndex + 1] = value[..indexToMutate] + replacement + value[(indexToMutate + 1)..];
         return Multiaddress.Decode(string.Join('/', parts));
     }
 

--- a/src/libp2p/Libp2p.Protocols.WebRtc.Tests/WebRtcDirectNoiseHandshakeTests.cs
+++ b/src/libp2p/Libp2p.Protocols.WebRtc.Tests/WebRtcDirectNoiseHandshakeTests.cs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using Google.Protobuf;
+using Nethermind.Libp2p.Core;
+using Nethermind.Libp2p.Protocols.Noise.Dto;
+using Nethermind.Libp2p.Protocols.WebRtc.Internals;
+using Noise;
+using System.Security.Cryptography;
+using System.Text;
+using PublicKey = Nethermind.Libp2p.Core.Dto.PublicKey;
+
+namespace Nethermind.Libp2p.Protocols.WebRtc.Tests;
+
+[TestFixture]
+public class WebRtcDirectNoiseHandshakeTests
+{
+    private const string PayloadSigPrefix = "noise-libp2p-static-key:";
+
+    [Test]
+    public async Task HandshakeAsync_AuthenticatesRemoteIdentity()
+    {
+        Channel initiatorChannel = new();
+        IChannel responderChannel = initiatorChannel.Reverse;
+        Identity initiator = new();
+        Identity responder = new();
+        byte[] prologue = Encoding.UTF8.GetBytes("test-prologue");
+
+        Task<(IChannel Encrypted, PublicKey RemoteKey)> initiatorTask = WebRtcDirectNoiseHandshake.HandshakeAsync(
+            initiatorChannel,
+            initiator,
+            prologue,
+            isInitiator: true,
+            CancellationToken.None);
+        Task<(IChannel Encrypted, PublicKey RemoteKey)> responderTask = WebRtcDirectNoiseHandshake.HandshakeAsync(
+            responderChannel,
+            responder,
+            prologue,
+            isInitiator: false,
+            CancellationToken.None);
+
+        (IChannel initiatorEncrypted, PublicKey initiatorRemoteKey) = await initiatorTask;
+        (IChannel responderEncrypted, PublicKey responderRemoteKey) = await responderTask;
+
+        Assert.That(new Identity(initiatorRemoteKey).PeerId, Is.EqualTo(responder.PeerId));
+        Assert.That(new Identity(responderRemoteKey).PeerId, Is.EqualTo(initiator.PeerId));
+
+        await initiatorEncrypted.CloseAsync();
+        await responderEncrypted.CloseAsync();
+    }
+
+    [Test]
+    public void ParseAndValidateRemoteKey_RejectsIdentitySignatureForDifferentKey()
+    {
+        KeyPair staticKey = KeyPair.Generate();
+        Identity claimedIdentity = new();
+        Identity signer = new();
+        byte[] sigInput = [.. Encoding.UTF8.GetBytes(PayloadSigPrefix), .. staticKey.PublicKey];
+        NoiseHandshakePayload payload = new()
+        {
+            IdentityKey = claimedIdentity.PublicKey.ToByteString(),
+            IdentitySig = ByteString.CopyFrom(signer.Sign(sigInput)),
+        };
+        byte[] payloadBytes = payload.ToByteArray();
+
+        Assert.That(
+            () => WebRtcDirectNoiseHandshake.ParseAndValidateRemoteKey(payloadBytes, payloadBytes.Length, staticKey.PublicKey),
+            Throws.TypeOf<CryptographicException>());
+    }
+}

--- a/src/libp2p/Libp2p.Protocols.WebRtc/Internals/WebRtcDirectNoiseHandshake.cs
+++ b/src/libp2p/Libp2p.Protocols.WebRtc/Internals/WebRtcDirectNoiseHandshake.cs
@@ -8,6 +8,7 @@ using NoiseHandshakePayload = Nethermind.Libp2p.Protocols.Noise.Dto.NoiseHandsha
 using Noise;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Nethermind.Libp2p.Protocols.WebRtc.Internals;
@@ -39,7 +40,7 @@ internal static class WebRtcDirectNoiseHandshake
             byte[] msg1Raw = await ReadFramedAsync(channel, token);
             byte[] msg1Buf = new byte[Protocol.MaxMessageLength];
             (int r1, _, _) = hs.ReadMessage(msg1Raw, msg1Buf);
-            remoteKey = ParseRemoteKey(msg1Buf, r1);
+            remoteKey = ParseAndValidateRemoteKey(msg1Buf, r1, hs.RemoteStaticPublicKey);
 
             byte[] identityPayload = BuildIdentityPayload(localIdentity, staticKey.PublicKey);
             byte[] msg2Buf = new byte[Protocol.MaxMessageLength];
@@ -61,7 +62,7 @@ internal static class WebRtcDirectNoiseHandshake
             byte[] msg2Raw = await ReadFramedAsync(channel, token);
             byte[] msg2Buf = new byte[Protocol.MaxMessageLength];
             (int r2, _, Transport t) = hs.ReadMessage(msg2Raw, msg2Buf);
-            remoteKey = ParseRemoteKey(msg2Buf, r2);
+            remoteKey = ParseAndValidateRemoteKey(msg2Buf, r2, hs.RemoteStaticPublicKey);
             transport = t;
         }
 
@@ -79,18 +80,51 @@ internal static class WebRtcDirectNoiseHandshake
         return payload.ToByteArray();
     }
 
-    private static PublicKey ParseRemoteKey(byte[] payloadBuffer, int payloadLength)
+    internal static PublicKey ParseAndValidateRemoteKey(byte[] payloadBuffer, int payloadLength, ReadOnlySpan<byte> remoteStaticPublicKey)
     {
+        if (payloadLength <= 0)
+        {
+            throw new CryptographicException("Noise handshake payload is empty.");
+        }
+
+        if (remoteStaticPublicKey.IsEmpty)
+        {
+            throw new CryptographicException("Noise handshake did not expose the remote static public key.");
+        }
+
         NoiseHandshakePayload envelope = NoiseHandshakePayload.Parser.ParseFrom(payloadBuffer.AsSpan(0, payloadLength));
-        return PublicKey.Parser.ParseFrom(envelope.IdentityKey);
+        PublicKey remoteKey = PublicKey.Parser.ParseFrom(envelope.IdentityKey);
+        byte[] signature = envelope.IdentitySig.ToByteArray();
+        if (signature.Length == 0)
+        {
+            throw new CryptographicException("Noise handshake identity signature is missing.");
+        }
+
+        Identity remoteIdentity = new(remoteKey);
+        byte[] sigInput = [.. Encoding.UTF8.GetBytes(PayloadSigPrefix), .. remoteStaticPublicKey.ToArray()];
+        if (!remoteIdentity.VerifySignature(sigInput, signature))
+        {
+            throw new CryptographicException("Noise handshake identity signature is invalid.");
+        }
+
+        return remoteKey;
     }
 
     private static async Task WriteFramedAsync(IChannel channel, byte[] buffer, int length, CancellationToken token)
     {
+        if (length > ushort.MaxValue)
+        {
+            throw new InvalidOperationException($"Noise handshake frame is too large: {length} bytes.");
+        }
+
         byte[] frame = new byte[2 + length];
         BinaryPrimitives.WriteUInt16BigEndian(frame, (ushort)length);
         buffer.AsSpan(0, length).CopyTo(frame.AsSpan(2));
-        await channel.WriteAsync(new ReadOnlySequence<byte>(frame), token);
+        IOResult result = await channel.WriteAsync(new ReadOnlySequence<byte>(frame), token);
+        if (result != IOResult.Ok)
+        {
+            throw new InvalidOperationException($"Noise handshake write failed: {result}");
+        }
     }
 
     private static async Task<byte[]> ReadFramedAsync(IChannel channel, CancellationToken token)

--- a/src/libp2p/Libp2p.Protocols.WebRtc/WebRtcDirectProtocol.cs
+++ b/src/libp2p/Libp2p.Protocols.WebRtc/WebRtcDirectProtocol.cs
@@ -7,6 +7,8 @@ using Multiformats.Address.Net;
 using Nethermind.Libp2p.Core;
 using Nethermind.Libp2p.Core.Dto;
 using Nethermind.Libp2p.Protocols.WebRtc.Internals;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.X509;
 using SIPSorcery.Net;
 using System.Net;
 using System.Net.Sockets;
@@ -29,10 +31,13 @@ public class WebRtcDirectProtocol : ITransportProtocol
     private readonly WebRtcDirectReplayWindow _replayWindow = new();
     private readonly WebRtcDirectRateLimiter _offerRateLimiter = new();
     private readonly SemaphoreSlim _incomingOfferSlots = new(MaxConcurrentIncomingOffers, MaxConcurrentIncomingOffers);
+    private readonly RTCCertificate2 _certificate;
+    private readonly DtlsFingerprint _fingerprint;
 
     public WebRtcDirectProtocol(ILoggerFactory? loggerFactory = null)
     {
         _logger = loggerFactory?.CreateLogger<WebRtcDirectProtocol>();
+        (_certificate, _fingerprint) = CreateLocalCertificate();
     }
 
     public string Id => "webrtc-direct";
@@ -52,8 +57,7 @@ public class WebRtcDirectProtocol : ITransportProtocol
             endpoint = (IPEndPoint)udp.Client.LocalEndPoint!;
         }
 
-        DtlsFingerprint listenerFingerprint = await ProbeListenerFingerprintAsync(token);
-        Multiaddress listenerAddr = WebRtcDirectMultiaddr.Build(endpoint, listenerFingerprint);
+        Multiaddress listenerAddr = WebRtcDirectMultiaddr.Build(endpoint, _fingerprint);
         context.ListenerReady(listenerAddr);
 
         _logger?.LogInformation("WebRTC-Direct listening on {Endpoint}", endpoint);
@@ -122,8 +126,8 @@ public class WebRtcDirectProtocol : ITransportProtocol
             Task<RTCDataChannel> noiseOpenTask = WaitForDataChannelOpenAsync(noiseDataChannel, token);
             Task connectionTask = WaitForConnectionAsync(pc, token);
 
-            DtlsFingerprint dialerFingerprint = await ProbeLocalFingerprintAsync(pc, token);
-            RTCSessionDescriptionInit offer = WebRtcDirectSdp.BuildOffer(endpoint, dialerFingerprint);
+            RTCSessionDescriptionInit offer = pc.createOffer(new RTCOfferOptions { X_WaitForIceGatheringToComplete = true });
+            ValidateExpectedFingerprint(WebRtcDirectSdp.ExtractFingerprint(offer.sdp ?? string.Empty), _fingerprint, "offer");
             string signedOffer = WebRtcDirectSignaling.BuildSignedPayload(
                 WebRtcDirectSignalType.Offer,
                 context.Peer.Identity,
@@ -136,7 +140,7 @@ public class WebRtcDirectProtocol : ITransportProtocol
             RTCSessionDescriptionInit answer = await ReceiveAnswerAsync(signalingUdp, endpoint, signalingSessionId, token);
             DtlsFingerprint answerFingerprint = WebRtcDirectSdp.ExtractFingerprint(answer.sdp ?? string.Empty);
             ValidateExpectedFingerprint(answerFingerprint, expectedFingerprint, "answer");
-            pc.setRemoteDescription(answer);
+            EnsureRemoteDescriptionApplied(pc.setRemoteDescription(answer), "answer");
 
             await connectionTask;
             RTCDataChannel openedNoiseDataChannel = await noiseOpenTask;
@@ -148,7 +152,7 @@ public class WebRtcDirectProtocol : ITransportProtocol
             connectionContext.State.RemoteAddress = endpoint.ToMultiaddress(ProtocolType.Udp);
 
             DataChannelOverIChannel rawChannel = new(openedNoiseDataChannel);
-            byte[] prologue = WebRtcNoisePrologue.Build(dialerFingerprint, expectedFingerprint);
+            byte[] prologue = WebRtcNoisePrologue.Build(_fingerprint, expectedFingerprint);
             (IChannel encryptedChannel, PublicKey remoteKey) = await WebRtcDirectNoiseHandshake.HandshakeAsync(
                 rawChannel, context.Peer.Identity, prologue, isInitiator: true, token);
             connectionContext.State.RemotePublicKey = remoteKey;
@@ -180,10 +184,13 @@ public class WebRtcDirectProtocol : ITransportProtocol
                 _replayWindow);
             RTCSessionDescriptionInit offer = new() { type = RTCSdpType.offer, sdp = remoteOfferSdp };
             DtlsFingerprint offeredFingerprint = WebRtcDirectSdp.ExtractFingerprint(remoteOfferSdp);
-            pc.setRemoteDescription(offer);
+            EnsureRemoteDescriptionApplied(pc.setRemoteDescription(offer), "offer");
 
-            DtlsFingerprint localFingerprint = await ProbeLocalFingerprintAsync(pc, token);
-            RTCSessionDescriptionInit answer = WebRtcDirectSdp.BuildAnswer(offer, localFingerprint);
+            RTCDataChannel noiseChannel = await pc.createDataChannel(NoiseChannelLabel, new RTCDataChannelInit { negotiated = true, id = 0 });
+            Task<RTCDataChannel> noiseOpenTask = WaitForDataChannelOpenAsync(noiseChannel, token);
+
+            RTCSessionDescriptionInit answer = pc.createAnswer();
+            ValidateExpectedFingerprint(WebRtcDirectSdp.ExtractFingerprint(answer.sdp ?? string.Empty), _fingerprint, "answer");
             string signedAnswer = WebRtcDirectSignaling.BuildSignedPayload(
                 WebRtcDirectSignalType.Answer,
                 context.Peer.Identity,
@@ -194,8 +201,6 @@ public class WebRtcDirectProtocol : ITransportProtocol
             byte[] answerBytes = Encoding.UTF8.GetBytes(AnswerPrefix + signedAnswer);
             await signalingUdp.SendAsync(answerBytes, answerBytes.Length, remoteEndpoint);
 
-            RTCDataChannel noiseChannel = await pc.createDataChannel(NoiseChannelLabel, new RTCDataChannelInit { negotiated = true, id = 0 });
-            Task<RTCDataChannel> noiseOpenTask = WaitForDataChannelOpenAsync(noiseChannel, token);
             await WaitForConnectionAsync(pc, token);
             ValidateRemoteFingerprint(pc, offeredFingerprint);
             RTCDataChannel openedNoiseChannel = await noiseOpenTask;
@@ -205,7 +210,7 @@ public class WebRtcDirectProtocol : ITransportProtocol
             connectionContext.State.RemoteAddress = remoteEndpoint.ToMultiaddress(ProtocolType.Udp);
 
             DataChannelOverIChannel rawChannel = new(openedNoiseChannel);
-            byte[] prologue = WebRtcNoisePrologue.Build(offeredFingerprint, localFingerprint);
+            byte[] prologue = WebRtcNoisePrologue.Build(offeredFingerprint, _fingerprint);
             (IChannel encryptedChannel, PublicKey remoteKey) = await WebRtcDirectNoiseHandshake.HandshakeAsync(
                 rawChannel, context.Peer.Identity, prologue, isInitiator: false, token);
             connectionContext.State.RemotePublicKey = remoteKey;
@@ -222,15 +227,28 @@ public class WebRtcDirectProtocol : ITransportProtocol
         }
     }
 
-    private static RTCPeerConnection CreatePeerConnection()
+    private RTCPeerConnection CreatePeerConnection()
     {
         RTCConfiguration config = new()
         {
             X_ICEIncludeAllInterfaceAddresses = false,
             X_GatherTimeoutMs = 2000,
+            certificates2 = [_certificate],
         };
 
         return new RTCPeerConnection(config);
+    }
+
+    private static (RTCCertificate2 Certificate, DtlsFingerprint Fingerprint) CreateLocalCertificate()
+    {
+        (X509Certificate certificate, AsymmetricKeyParameter privateKey) = DtlsUtils.CreateSelfSignedEcdsaCert();
+        RTCCertificate2 rtcCertificate = new()
+        {
+            Certificate = certificate,
+            PrivateKey = privateKey,
+        };
+
+        return (rtcCertificate, DtlsFingerprint.FromRtcFingerprint(DtlsUtils.Fingerprint(certificate)));
     }
 
     private async Task<RTCSessionDescriptionInit> ReceiveAnswerAsync(
@@ -310,68 +328,12 @@ public class WebRtcDirectProtocol : ITransportProtocol
         }
     }
 
-    private Task<DtlsFingerprint> ProbeLocalFingerprintAsync(RTCPeerConnection pc, CancellationToken token)
+    private static void EnsureRemoteDescriptionApplied(SetDescriptionResultEnum result, string source)
     {
-        _ = token;
-        if (TryGetLocalFingerprint(pc, out DtlsFingerprint? fingerprint))
+        if (result != SetDescriptionResultEnum.OK)
         {
-            _logger?.LogDebug("DTLS fingerprint resolved via DtlsCertificateFingerprint (pre-offer).");
-            return Task.FromResult(fingerprint!);
-        }
-
-        _logger?.LogDebug("DtlsCertificateFingerprint unavailable; probing via createOffer SDP.");
-        RTCSessionDescriptionInit probeOffer = pc.createOffer(null);
-        pc.setLocalDescription(probeOffer);
-
-        if (!string.IsNullOrWhiteSpace(probeOffer.sdp))
-        {
-            try
-            {
-                DtlsFingerprint fromSdp = WebRtcDirectSdp.ExtractFingerprint(probeOffer.sdp);
-                _logger?.LogDebug("DTLS fingerprint resolved via SDP a=fingerprint line.");
-                return Task.FromResult(fromSdp);
-            }
-            catch (FormatException ex)
-            {
-                _logger?.LogDebug(ex, "SDP probe did not contain an a=fingerprint line.");
-            }
-        }
-
-        if (TryGetLocalFingerprint(pc, out fingerprint))
-        {
-            _logger?.LogDebug("DTLS fingerprint resolved via DtlsCertificateFingerprint (post-setLocalDescription).");
-            return Task.FromResult(fingerprint!);
-        }
-
-        _logger?.LogWarning(
-            "Host WebRTC stack did not expose a local DTLS fingerprint via any probe path " +
-            "(DtlsCertificateFingerprint pre/post-offer, SDP a=fingerprint). " +
-            "SIPSorcery may require an explicit certificate or a newer runtime.");
-        throw new InvalidOperationException("Unable to determine local DTLS fingerprint from RTCPeerConnection.");
-    }
-
-    private static bool TryGetLocalFingerprint(RTCPeerConnection pc, out DtlsFingerprint? fingerprint)
-    {
-        fingerprint = null;
-        if (pc.DtlsCertificateFingerprint is null)
-        {
-            return false;
-        }
-
-        try
-        {
-            fingerprint = DtlsFingerprint.FromRtcFingerprint(pc.DtlsCertificateFingerprint);
-            return true;
-        }
-        catch (FormatException)
-        {
-            return false;
+            throw new InvalidOperationException($"Failed to apply WebRTC remote {source} SDP: {result}.");
         }
     }
 
-    private async Task<DtlsFingerprint> ProbeListenerFingerprintAsync(CancellationToken token)
-    {
-        using RTCPeerConnection probe = CreatePeerConnection();
-        return await ProbeLocalFingerprintAsync(probe, token);
-    }
 }

--- a/src/samples/chat/ConsoleReader.cs
+++ b/src/samples/chat/ConsoleReader.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: MIT
 
 internal class ConsoleReader
@@ -9,7 +9,7 @@ internal class ConsoleReader
     public Task<string> ReadLineAsync(CancellationToken token = default)
     {
         TaskCompletionSource<string> result = new();
-        token.Register(() => { result.SetResult(""); });
+        token.Register(() => { result.TrySetResult(""); });
         _requests.Enqueue(result);
         if (!_isRequested)
         {
@@ -17,9 +17,9 @@ internal class ConsoleReader
             Task.Run(() =>
             {
                 string? input = Console.ReadLine();
-                while (_requests.TryDequeue(out TaskCompletionSource<string> src))
+                while (_requests.TryDequeue(out TaskCompletionSource<string>? src))
                 {
-                    Task.Run(() => src.SetResult(input));
+                    Task.Run(() => src.TrySetResult(input ?? string.Empty));
                 }
 
                 _isRequested = false;

--- a/src/samples/transport-interop/Program.cs
+++ b/src/samples/transport-interop/Program.cs
@@ -8,6 +8,7 @@ using Nethermind.Libp2p;
 using Nethermind.Libp2p.Core;
 using Nethermind.Libp2p.Protocols;
 using Nethermind.Libp2p.Protocols.Tls;
+using Nethermind.Libp2p.Protocols.WebRtc;
 using StackExchange.Redis;
 using System.Diagnostics;
 using System.Net;
@@ -24,7 +25,7 @@ try
     }
 
     // For QUIC, muxer and security are built-in and not required
-    bool isStacklessProtocol = transport == "quic-v1" || transport == "webtransport";
+    bool isStacklessProtocol = transport == "quic-v1" || transport == "webtransport" || transport == "webrtc-direct";
 
     string muxer = Environment.GetEnvironmentVariable("MUXER") ?? "";
     if (string.IsNullOrEmpty(muxer) && !isStacklessProtocol)
@@ -201,7 +202,7 @@ class TestPlansPeerFactoryBuilder : PeerFactoryBuilderBase<TestPlansPeerFactoryB
         _encryption = encryption;
     }
 
-    private static readonly string[] stacklessProtocols = ["quic-v1", "webtransport"];
+    private static readonly string[] stacklessProtocols = ["quic-v1", "webtransport", "webrtc-direct"];
 
     protected override ProtocolRef[] BuildStack(IEnumerable<ProtocolRef> additionalProtocols)
     {
@@ -210,6 +211,7 @@ class TestPlansPeerFactoryBuilder : PeerFactoryBuilderBase<TestPlansPeerFactoryB
             "tcp" => Get<IpTcpProtocol>(),
             // TODO: Improve QUIC interoperability
             "quic-v1" => Get<QuicProtocol>(),
+            "webrtc-direct" => Get<WebRtcDirectProtocol>(),
             _ => throw new NotImplementedException(),
         };
 
@@ -246,6 +248,7 @@ class TestPlansPeerFactoryBuilder : PeerFactoryBuilderBase<TestPlansPeerFactoryB
     {
         "tcp" => $"/ip4/{ip}/tcp/{port}",
         "quic-v1" => $"/ip4/{ip}/udp/{port}/quic-v1",
+        "webrtc-direct" => $"/ip4/{ip}/udp/{port}/webrtc-direct",
         _ => throw new NotImplementedException(),
     };
 }

--- a/src/samples/transport-interop/README.md
+++ b/src/samples/transport-interop/README.md
@@ -1,6 +1,6 @@
 # Transport interop app
 
-A .NET libp2p transport interoperability testing application that supports TCP and QUIC transports.
+A .NET libp2p transport interoperability testing application that supports TCP, QUIC, and WebRTC-Direct transports.
 
 ## Prerequisites
 
@@ -15,11 +15,11 @@ docker run -d --name redis-interop -p 6379:6379 redis:alpine
 ## Environment Variables
 
 Required:
-- `TRANSPORT`: Transport protocol to use (`tcp`, `quic-v1`)
+- `TRANSPORT`: Transport protocol to use (`tcp`, `quic-v1`, `webrtc-direct`)
 - `IS_DIALER`: Whether this instance is a dialer (`true`) or listener (`false`)
 - `TEST_KEY`: Key prefix for Redis communication
-- `SECURE_CHANNEL`: Security protocol (`noise`) - not required for stackless protocols like `quic-v1`
-- `MUXER`: Multiplexer protocol (`yamux`) - not required for stackless protocols like `quic-v1`
+- `SECURE_CHANNEL`: Security protocol (`noise`) - not required for stackless protocols like `quic-v1` or `webrtc-direct`
+- `MUXER`: Multiplexer protocol (`yamux`) - not required for stackless protocols like `quic-v1` or `webrtc-direct`
 
 Optional:
 - `REDIS_ADDR`: Redis server address (default: empty)
@@ -48,5 +48,4 @@ dotnet run
 # build from repo root
 docker build -f src/samples/transport-interop/Dockerfile -t transport-interop:latest .
 # run from repository root
-
 

--- a/src/samples/transport-interop/TransportInterop.csproj
+++ b/src/samples/transport-interop/TransportInterop.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\libp2p\Libp2p.Protocols.IpTcp\Libp2p.Protocols.IpTcp.csproj" />
     <ProjectReference Include="..\..\libp2p\Libp2p.Protocols.Noise\Libp2p.Protocols.Noise.csproj" />
     <ProjectReference Include="..\..\libp2p\Libp2p.Protocols.Tls\Libp2p.Protocols.Tls.csproj" />
+    <ProjectReference Include="..\..\libp2p\Libp2p.Protocols.WebRtc\Libp2p.Protocols.WebRtc.csproj" />
     <ProjectReference Include="..\..\libp2p\Libp2p.Protocols.Ping\Libp2p.Protocols.Ping.csproj" />
     <ProjectReference Include="..\..\libp2p\Libp2p.Protocols.Yamux\Libp2p.Protocols.Yamux.csproj" />
     <ProjectReference Include="..\..\libp2p\Libp2p.Protocols.Identify\Libp2p.Protocols.Identify.csproj" />


### PR DESCRIPTION
- Use SIPSorcery-generated WebRTC SDP for real ICE credentials/candidates.
- Keep stable per-protocol DTLS certificate/fingerprint for `/certhash`.
- Validate remote DTLS fingerprint and SDP application results.
- Authenticate WebRTC-Direct Noise static keys against signed libp2p identity payloads.
- Add focused Noise handshake tests and explicit WebRTC-Direct loopback checks.
- Wire `webrtc-direct` into `transport-interop`.
- Fix warnings-as-errors and NuGet audit blockers.